### PR TITLE
Update middleware.go

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/h2non/bimg"
 	"github.com/rs/cors"
-	"gopkg.in/throttled/throttled.v2"
-	"gopkg.in/throttled/throttled.v2/store/memstore"
+	"github.com/throttled/throttled/v2"
+	"github.com/throttled/throttled/v2/store/memstore"
 )
 
 func Middleware(fn func(http.ResponseWriter, *http.Request), o ServerOptions) http.Handler {


### PR DESCRIPTION
Before these changes, compiling myself I would get:

```
go: downloading github.com/throttled/throttled v1.0.0
go: downloading github.com/throttled/throttled/v2 v2.7.1
go: downloading github.com/throttled/throttled v2.2.5+incompatible
go get: gopkg.in/throttled/throttled.v2@v2.0.3 updating to
	gopkg.in/throttled/throttled.v2@v2.7.1: parsing go.mod:
	module declares its path as: github.com/throttled/throttled/v2
	        but was required as: gopkg.in/throttled/throttled.v2
```